### PR TITLE
Flexjoin draft1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Depends:
 Imports:
     crayon,
     data.table (>= 1.13.0),
-    dplyr (>= 1.0.3),
+    dplyr (>= 1.0.99.9000),
     glue,
     lifecycle,
     rlang (>= 1.0.4),
@@ -36,7 +36,8 @@ Suggests:
     tidyr (>= 1.1.0),
     waldo (>= 0.3.1)
 Remotes:
-    r-lib/tidyselect
+    r-lib/tidyselect,
+    tidyverse/dplyr
 VignetteBuilder: 
     knitr
 Config/Needs/website: tidyverse/tidytemplate

--- a/R/step-join.R
+++ b/R/step-join.R
@@ -1,4 +1,4 @@
-step_join <- function(x, y, on, style, copy, suffix = c(".x", ".y")) {
+step_join <- function(x, y, on, style, copy, suffix = c(".x", ".y"), keep) {
   stopifnot(is_step(x))
   y <- dtplyr_auto_copy(x, y, copy = copy)
   stopifnot(is_step(y))
@@ -116,39 +116,73 @@ dt_call.dtplyr_step_join <- function(x, needs_copy = x$needs_copy) {
 #'
 #' band_dt %>% semi_join(instrument_dt)
 #' band_dt %>% anti_join(instrument_dt)
-left_join.dtplyr_step <- function(x, y, ..., by = NULL, copy = FALSE, suffix = c(".x", ".y")) {
-  step_join(x, y, by, style = "left", copy = copy, suffix = suffix)
+left_join.dtplyr_step <- function(x, 
+                                  y, 
+                                  by = NULL, 
+                                  copy = FALSE, 
+                                  suffix = c(".x", ".y"), 
+                                  ...,
+                                  keep = NULL) {
+  step_join(x, y, by, style = "left", copy = copy, suffix = suffix, keep = keep)
 }
 
 #' @importFrom dplyr right_join
 #' @export
-right_join.dtplyr_step <- function(x, y, ..., by = NULL, copy = FALSE, suffix = c(".x", ".y")) {
-  step_join(x, y, by, style = "right", copy = copy, suffix = suffix)
+right_join.dtplyr_step <- function(x, 
+                                   y, 
+                                   by = NULL, 
+                                   copy = FALSE, 
+                                   suffix = c(".x", ".y"), 
+                                   ...,
+                                   keep = NULL) {
+  step_join(x, y, by, style = "right", copy = copy, suffix = suffix, keep = keep)
 }
 
 
 #' @importFrom dplyr inner_join
 #' @export
-inner_join.dtplyr_step <- function(x, y, ..., by = NULL, copy = FALSE, suffix = c(".x", ".y")) {
-  step_join(x, y, on = by, style = "inner", copy = copy, suffix = suffix)
+inner_join.dtplyr_step <- function(x, 
+                                   y, 
+                                   by = NULL, 
+                                   copy = FALSE, 
+                                   suffix = c(".x", ".y"), 
+                                   ...,
+                                   keep = NULL) {
+  step_join(x, y, on = by, style = "inner", copy = copy, suffix = suffix, keep = keep)
 }
 
 #' @importFrom dplyr full_join
 #' @export
-full_join.dtplyr_step <- function(x, y, ..., by = NULL, copy = FALSE, suffix = c(".x", ".y")) {
-  step_join(x, y, on = by, style = "full", copy = copy, suffix = suffix)
+full_join.dtplyr_step <- function(x, 
+                                  y, 
+                                  by = NULL, 
+                                  copy = FALSE, 
+                                  suffix = c(".x", ".y"), 
+                                  ...,
+                                  keep = NULL) {
+  step_join(x, y, on = by, style = "full", copy = copy, suffix = suffix, keep = keep)
 }
 
 #' @importFrom dplyr anti_join
 #' @export
-anti_join.dtplyr_step <- function(x, y, ..., by = NULL, copy = FALSE) {
-  step_join(x, y, on = by, style = "anti", copy = copy)
+anti_join.dtplyr_step <- function(x, 
+                                  y, 
+                                  by = NULL, 
+                                  copy = FALSE, 
+                                  ...,
+                                  keep = NULL) {
+  step_join(x, y, on = by, style = "anti", copy = copy, keep = keep)
 }
 
 #' @importFrom dplyr semi_join
 #' @export
-semi_join.dtplyr_step <- function(x, y, ..., by = NULL, copy = FALSE) {
-  step_join(x, y, on = by, style = "semi", copy = copy)
+semi_join.dtplyr_step <- function(x, 
+                                  y, 
+                                  by = NULL, 
+                                  copy = FALSE, 
+                                  ...,
+                                  keep = NULL) {
+  step_join(x, y, on = by, style = "semi", copy = copy, keep = keep)
 }
 
 # helpers -----------------------------------------------------------------

--- a/R/step-join.R
+++ b/R/step-join.R
@@ -40,7 +40,7 @@ step_join <- function(x, y, on, style, copy, suffix = c(".x", ".y"), keep) {
 
   x_sim <- simulate_vars(x)
   y_sim <- simulate_vars(y)
-  vars <- dplyr_join_vars(x_sim, y_sim, on$x, on$y, suffix = suffix)
+  vars <- dplyr_join_vars(x_sim, y_sim, on$x, on$y, suffix = suffix, keep = keep)
 
   if (any(duplicated(vars_out_dt))) {
     step_setnames(out, colorder, vars, in_place = FALSE)
@@ -221,8 +221,8 @@ add_suffixes <- function (x, y, suffix) {
   x
 }
 
-dplyr_join_vars <- function(x, y, on_x, on_y, suffix) {
-  colnames(left_join(x, y, by = stats::setNames(on_y, on_x), suffix = suffix))
+dplyr_join_vars <- function(x, y, on_x, on_y, suffix, keep) {
+  colnames(left_join(x, y, by = stats::setNames(on_y, on_x), suffix = suffix, keep = keep))
 }
 
 dt_join_vars <- function(x, y, on_x, on_y, suffix, style) {

--- a/R/step-join.R
+++ b/R/step-join.R
@@ -20,6 +20,8 @@ step_join <- function(x, y, on, style, copy, suffix = c(".x", ".y"), keep) {
   vars_out_dt <- dt_join_vars(x$vars, y$vars, on$x, on$y, suffix = suffix, style = style)
   colorder <- dt_join_colorder(x$vars, y$vars, on$x, on$y, style)
 
+  join_needs_j <- is_true(keep) || any(on$condition != "==")
+
   # TODO suppress warning in merge
   # "column names ... are duplicated in the result
   out <- new_step(
@@ -188,7 +190,7 @@ semi_join.dtplyr_step <- function(x,
 
 # helpers -----------------------------------------------------------------
 
-create_dt_on <- function(on, style){
+create_dt_on <- function(on, style) {
   if (style == "left") {
     on[c('x', 'y')] <- on[c('y', 'x')]
   }

--- a/R/step-join.R
+++ b/R/step-join.R
@@ -16,6 +16,7 @@ step_join <- function(x, y, on, style, copy, suffix = c(".x", ".y"), keep) {
   }
 
   on$dt_on <- create_dt_on(on, style)
+  # todo: error when join is non-equi and style == "full" (not possible in dt)
 
   vars_out_dt <- dt_join_vars(x$vars, y$vars, on$x, on$y, suffix = suffix, style = style)
   colorder <- dt_join_colorder(x$vars, y$vars, on$x, on$y, style)

--- a/R/step-join.R
+++ b/R/step-join.R
@@ -5,15 +5,16 @@ step_join <- function(x, y, on, style, copy, suffix = c(".x", ".y"), keep) {
   stopifnot(is.null(on) || is.character(on) || inherits(on, "dplyr_join_by"))
   style <- match.arg(style, c("inner", "full", "right", "left", "semi", "anti"))
 
-  if (is_character(on, 0)) {
-    return(cross_join(x, y))
-  }
-
   if (is_null(on)) {
     on <- dplyr:::join_by_common(x$vars, y$vars)
   } else {
     on <- dplyr:::as_join_by(on)
   }
+
+  if (on$cross) {
+    return(cross_join(x, y))
+  }
+
   on$dt_on <- create_dt_on(on, style)
 
   vars_out_dt <- dt_join_vars(x$vars, y$vars, on$x, on$y, suffix = suffix, style = style)


### PR DESCRIPTION
Very rough draft of dtplyr support for new dplyr flexible join syntax.

dplyr has some pretty nice modular functions for most of the logic we'd need to add, but they aren't exported. I'm thinking we should add a "compat-dplyr-joins.R" with these functions rather than re-implementing the same logic.

Parsing the `by` argument:
`dplyr:::join_by_common()`
`dplyr:::as_join_by()`
Producing output columns (which are included, in what order, with names):
`dplyr:::join_cols()`